### PR TITLE
Bugfix with composer scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,8 @@ For Laravel >=5.5.0 and < 5.7 please use 0.3 version.
 In your terminal:
 
 ```sh
-composer install novius/laravel-artisan-commands
+composer require novius/laravel-artisan-commands
 ```
-
-Then, if you are on Laravel 5.4 (no need for Laravel 5.5 and higher), register the service provider to your `config/app.php` file:
-
-```php
-'providers' => [
-    ...
-    Novius\ArtisanCommands\ArtisanCommandsServiceProvider::class,
-];
-```
-
-
 
 ## Usage & Features
 

--- a/src/Console/Database/Create.php
+++ b/src/Console/Database/Create.php
@@ -65,10 +65,8 @@ class Create extends Command
         // We have to clear database name config (and rollback it then), otherwise DB::unprepared() tries to connect
         // (and throw an "Unknown database" error)
         $this->changeDatabaseName('');
-        $sqlExec = DB::unprepared('CREATE DATABASE IF NOT EXISTS '.(string) $databaseName);
+        DB::unprepared('CREATE DATABASE IF NOT EXISTS '.(string) $databaseName);
         $this->changeDatabaseName($databaseName);
-
-        return $sqlExec;
     }
 
     /**


### PR DESCRIPTION
Fix following error : 

_Script php artisan db:create --connection=ci handling the test event returned with error code 1_
 
With this usage for example :
```
"scripts": {
        "test": [
            "php artisan db:create --connection=ci"
        ]
}
```